### PR TITLE
Fix problem caused by the new ClientBuilder in Stormpath Java S...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iws
 *.ipr
 target
+.idea/

--- a/core/src/main/java/com/stormpath/shiro/client/ClientFactory.java
+++ b/core/src/main/java/com/stormpath/shiro/client/ClientFactory.java
@@ -17,6 +17,7 @@ package com.stormpath.shiro.client;
 
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.client.ClientBuilder;
+import com.stormpath.sdk.client.Clients;
 import com.stormpath.shiro.cache.ShiroCacheManager;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.util.AbstractFactory;
@@ -64,7 +65,7 @@ public class ClientFactory extends AbstractFactory<Client> {
 
     public ClientFactory() {
         super();
-        this.clientBuilder = new ClientBuilder();
+        this.clientBuilder = Clients.builder();
     }
 
     @Override

--- a/core/src/test/groovy/com/stormpath/shiro/ClientIT.groovy
+++ b/core/src/test/groovy/com/stormpath/shiro/ClientIT.groovy
@@ -2,7 +2,7 @@ package com.stormpath.shiro
 
 import com.stormpath.sdk.cache.Caches
 import com.stormpath.sdk.client.Client
-import com.stormpath.sdk.client.ClientBuilder
+import com.stormpath.sdk.client.Clients
 import com.stormpath.sdk.resource.Deletable
 import org.junit.After
 import org.junit.Before
@@ -10,13 +10,11 @@ import org.junit.BeforeClass
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-
 class ClientIT {
 
     private static final Logger log = LoggerFactory.getLogger(ClientIT)
 
     static String apiKeyFileLocation = System.getProperty('user.home') + "/.stormpath/apiKey.properties"
-    static String baseUrl = 'https://api.stormpath.com/v1'
     static Client client
 
     List<Deletable> resourcesToDelete;
@@ -54,7 +52,7 @@ class ClientIT {
     // created in IntelliJ after that point will pick up these vars.
     static Client buildClient(boolean enableCaching=true) {
 
-        def builder = new ClientBuilder().setBaseUrl(baseUrl)
+        def builder = Clients.builder()
 
         //see if the api key file exists first - if so, use it:
         def file = new File(apiKeyFileLocation)

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <!-- Standard Dependencies: -->
         <shiro.version>1.2.2</shiro.version>
         <slf4j.version>1.6.6</slf4j.version>
-        <stormpath.sdk.version>0.9.1</stormpath.sdk.version>
+        <stormpath.sdk.version>1.0.alpha</stormpath.sdk.version>
 
         <!-- Test Dependencies: -->
         <easymock.version>3.0</easymock.version>


### PR DESCRIPTION
A runtime problem occurs when using the latest version of the stormpath-shiro plugin and the latest version of the Java stormpath-sdk. 

Updated pom file to latest version of Stormpath-SDK (1.0.alpha)

Added .idea folder to .gitignore to avoid issues for people working on Intellij.
