### PR TITLE
Bugfix/wont authz users from other realms

### DIFF
--- a/core/src/main/java/com/stormpath/shiro/realm/ApplicationRealm.java
+++ b/core/src/main/java/com/stormpath/shiro/realm/ApplicationRealm.java
@@ -20,9 +20,11 @@ import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.authc.AuthenticationRequest;
 import com.stormpath.sdk.authc.UsernamePasswordRequest;
 import com.stormpath.sdk.client.Client;
+import com.stormpath.sdk.directory.CustomData;
 import com.stormpath.sdk.group.Group;
 import com.stormpath.sdk.group.GroupList;
 import com.stormpath.sdk.resource.ResourceException;
+
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
@@ -141,6 +143,7 @@ public class ApplicationRealm extends AuthorizingRealm {
     private GroupPermissionResolver groupPermissionResolver;
     private AccountPermissionResolver accountPermissionResolver;
     private AccountRoleResolver accountRoleResolver;
+    private Map<String, String> customDataMappings;
 
     private Application application; //acquired via the client at runtime, not configurable by the Realm user
 
@@ -305,6 +308,14 @@ public class ApplicationRealm extends AuthorizingRealm {
         this.accountRoleResolver = accountRoleResolver;
     }
 
+    public Map<String, String> getCustomDataMappings() {
+        return customDataMappings;
+    }
+
+    public void setCustomDataMappings(final Map<String, String> customDataMappings) {
+        this.customDataMappings = customDataMappings;
+    }
+
     @Override
     protected void onInit() {
         super.onInit();
@@ -389,6 +400,14 @@ public class ApplicationRealm extends AuthorizingRealm {
         nullSafePut(props, "givenName", account.getGivenName());
         nullSafePut(props, "middleName", account.getMiddleName());
         nullSafePut(props, "surname", account.getSurname());
+        if (customDataMappings != null && !customDataMappings.isEmpty())
+        {
+            final CustomData customData = account.getCustomData();
+
+            for (String key : customDataMappings.keySet()) {
+                nullSafePut(props, customDataMappings.get(key), customData.get(key).toString());
+            }
+        }
 
         Collection<Object> principals = new ArrayList<Object>(2);
         principals.add(account.getHref());

--- a/core/src/main/java/com/stormpath/shiro/realm/ApplicationRealm.java
+++ b/core/src/main/java/com/stormpath/shiro/realm/ApplicationRealm.java
@@ -426,6 +426,10 @@ public class ApplicationRealm extends AuthorizingRealm {
     protected String getAccountHref(PrincipalCollection principals) {
         Collection c = principals.fromRealm(getName());
         //Based on the createPrincipals implementation above, the first one is the Account href:
+        if (c.isEmpty())
+        {
+            return principals.getPrimaryPrincipal().toString();
+        }
         return (String) c.iterator().next();
     }
 


### PR DESCRIPTION
If the user does not have a stormpath principal, we attempt to use the primary principal for authz so that we can leverage things like passthrough authenticators but still use stormpath permissions.